### PR TITLE
Use connection_options to disable ssl verification

### DIFF
--- a/lib/octorepl.rb
+++ b/lib/octorepl.rb
@@ -58,6 +58,12 @@ module Octorepl
         end
       end
 
+      if ! config.verify_ssl?
+        Octokit.configure do |c|
+          c.connection_options = { ssl: { verify: false } }
+        end
+      end
+
       login        = config.user
       access_token = config.token
       @octokit = Octokit::Client.new(login: login, access_token: access_token)
@@ -70,10 +76,6 @@ module Octorepl
       o.on('-h', '--host HOST') {|v| config.learn(:host, v) }
       o.on('--disable-ssl-verify') {|v| config.learn(:ssl_verify, !v) }
     }.parse!(argv)
-
-    if ! config.verify_ssl?
-      require 'octorepl/ssl_no_verify'
-    end
 
     hub_config = YAML.load_file(File.expand_path('~/.config/hub'))
     host_config = hub_config.fetch(config.host).first

--- a/lib/octorepl/ssl_no_verify.rb
+++ b/lib/octorepl/ssl_no_verify.rb
@@ -1,6 +1,0 @@
-require 'openssl'
-
-original_verbose = $VERBOSE
-$VERBOSE = nil # Supress warnings
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-$VERBOSE = original_verbose


### PR DESCRIPTION
This way would be more modest than overwriting a constant about SSL globally.

Reference: https://github.com/octokit/octokit.rb#ssl-connection-errors
